### PR TITLE
Add Strategy Type for Deployments with ReadWriteOnce PVC

### DIFF
--- a/charts/wakapi/templates/deployment.yaml
+++ b/charts/wakapi/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       {{- include "wakapi.selectorLabels" . | nindent 6 }}

--- a/charts/wakapi/values.yaml
+++ b/charts/wakapi/values.yaml
@@ -14,6 +14,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# The strategy to use for the deployment. Defaults to "RollingUpdate".
+# Set it to "Recreate" if you have a persistent volume with "ReadWriteOnce"-accessMode to prevent multiple access to the PVC on update.
+strategyType: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
In my setup I have a PVC that is ReadWriteOnce which does not allow RollingUpdate due to the new Pod on update trying to access the PVC, which is already locked by the previous Pod.

Therefore the strategy has to be set to "Recreate", which is currently not possible in the helm chart.

Thats what this PR does.