### PR TITLE
fix(config): add oidc variables

### DIFF
--- a/charts/wakapi/templates/config-map.yaml
+++ b/charts/wakapi/templates/config-map.yaml
@@ -73,3 +73,7 @@ data:
   WAKAPI_SENTRY_SAMPLE_RATE_HEARTBEATS: "{{ .Values.wakapi_config.sentry.sample_rate_heartbeats }}"
   WAKAPI_QUICK_START: "{{ .Values.wakapi_config.quick_start }}"
   WAKAPI_ENABLE_PPROF: "{{ .Values.wakapi_config.enable_pprof }}"
+  WAKAPI_OIDC_PROVIDER_NAME: "{{ .Values.wakapi_config.security.oidc[0].name }}"
+  WAKAPI_OIDC_PROVIDER_CLIENT_ID: "{{ .Values.wakapi_config.security.oidc[0].client_id }}"
+  WAKAPI_OIDC_PROVIDER_CLIENT_SECRET: "{{ .Values.wakapi_config.security.oidc[0].client_secret }}"
+  WAKAPI_OIDC_PROVIDER_ENDPOINT: "{{ .Values.wakapi_config.security.oidc[0].endpoint }}"


### PR DESCRIPTION
In the latest version of wakapi, OIDC-Support was added, including new config variables.
This PR adds them to the configMap.