### PR TITLE
Add new env to disable local auth

### DIFF
--- a/charts/wakapi/templates/config-map.yaml
+++ b/charts/wakapi/templates/config-map.yaml
@@ -77,3 +77,4 @@ data:
   WAKAPI_OIDC_PROVIDERS_0_CLIENT_ID: "{{ .Values.wakapi_config.security.oidc.client_id }}"
   WAKAPI_OIDC_PROVIDERS_0_CLIENT_SECRET: "{{ .Values.wakapi_config.security.oidc.client_secret }}"
   WAKAPI_OIDC_PROVIDERS_0_ENDPOINT: "{{ .Values.wakapi_config.security.oidc.endpoint }}"
+  WAKAPI_DISABLE_LOCAL_AUTH: "{{ .Values.wakapi_config.security.disable_local_auth }}"

--- a/charts/wakapi/values.yaml
+++ b/charts/wakapi/values.yaml
@@ -145,6 +145,7 @@ wakapi_config:
     ssl: false # whether to use tls for db connection (must be true for cockroachdb) (ignored for mysql and sqlite)
 
   security:
+    disable_local_auth: false  # set this to true if oidc should be the only way of authentication
     password_salt: # CHANGE !
     insecure_cookies: false # You need to set this to 'true' when on localhost
     cookie_max_age: 172800


### PR DESCRIPTION
The new env was added in the latest wakapi version "2.17.1".

This PR adds it to the configmap.